### PR TITLE
Add STATegRa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repo.
 - 2013 - [JIVE](https://genome.unc.edu/jive/) - joint & individual variance explained - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671601/)
 - 2014 - [MCIA](https://bioconductor.org/packages/omicade4) - multiple co-interia analysis - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4053266/)
 - 2014 - [RGCCA](https://cran.r-project.org/web/packages=RGCCA) - Regularized generalized CCA - [paper](https://www.ncbi.nlm.nih.gov/pubmed/24550197)
-- 2014 - [STATegRa](https://bioconductor.org/packages/STATegRa) DISCO, JIVE and O2PLS methods (there are several papers)
+- 2014 - [STATegRa](https://bioconductor.org/packages/STATegRa) - DISCO, JIVE and O2PLS methods (there are several papers)
 - 2016 - **Bayesian group factor analysis** - [paper](https://arxiv.org/abs/1411.2698)
 - 2016 - [MSFA](https://github.com/rdevito/MSFA) - multi-study factor analysis, unlike the other methods here, this is for same feature, different samples - [paper](https://arxiv.org/abs/1611.06350)
 - 2016 - [moGSA](https://bioconductor.org/packages/mogsa) - [paper](https://www.biorxiv.org/content/early/2016/04/03/046904)

--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ repo.
 
 ## Software packages and methods
 
+
 ### Multi-omics correlation analysis
 
-- 2009 - [Sparse mCCA](https://cran.r-project.org/web/packages/PMA/index.html) - [paper 1](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2697346/), [paper 2](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2861323/)
+- 2009 - [Sparse mCCA](https://cran.r-project.org/web/packages=PMA) - [paper 1](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2697346/), [paper 2](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2861323/)
 - 2010 - **Regularized dual CCA** - [paper](https://doi.org/10.1186/1471-2105-11-191)
 - 2013 - [JIVE](https://genome.unc.edu/jive/) - joint & individual variance explained - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671601/)
 - 2014 - [MCIA](https://bioconductor.org/packages/omicade4) - multiple co-interia analysis - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4053266/)
-- 2014 - [RGCCA](https://cran.r-project.org/web/packages/RGCCA/index.html) - Regularized generalized CCA - [paper](https://www.ncbi.nlm.nih.gov/pubmed/24550197)
+- 2014 - [RGCCA](https://cran.r-project.org/web/packages=RGCCA) - Regularized generalized CCA - [paper](https://www.ncbi.nlm.nih.gov/pubmed/24550197)
+- 2014 - [STATegRa](https://bioconductor.org/packages/STATegRa) DISCO, JIVE and O2PLS methods (there are several papers)
 - 2016 - **Bayesian group factor analysis** - [paper](https://arxiv.org/abs/1411.2698)
 - 2016 - [MSFA](https://github.com/rdevito/MSFA) - multi-study factor analysis, unlike the other methods here, this is for same feature, different samples - [paper](https://arxiv.org/abs/1611.06350)
 - 2016 - [moGSA](https://bioconductor.org/packages/mogsa) - [paper](https://www.biorxiv.org/content/early/2016/04/03/046904)
-- 2017 - [mixOmics](https://cran.r-project.org/web/packages/mixOmics/index.html) - [paper](https://doi.org/10.1371/journal.pcbi.1005752)
+- 2017 - [mixOmics](https://bioconductor.org/packages/mixOmics) - [paper](https://doi.org/10.1371/journal.pcbi.1005752)
 - 2018 - [AJIVE](https://github.com/idc9/r_jive) - angle-based JIVE - [paper](https://arxiv.org/abs/1704.02060)
 - 2018 - [MOFA](https://github.com/bioFAM/MOFA) - multi-omics factor analysis - [paper](http://msb.embopress.org/content/14/6/e8124)
 - 2018 - [PCA+CCA](https://github.com/pachterlab/PCACCA/) - [paper](https://www.biorxiv.org/content/early/2018/07/09/364448)
@@ -27,7 +29,7 @@ repo.
 
 ### Multi-omics classification
 
-- 2009 - [iCluster](https://cran.r-project.org/web/packages/iCluster/index.html) - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2800366/)
+- 2009 - [iCluster](https://cran.r-project.org/web/packages=iCluster) - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2800366/)
 - 2013 - [iCluster+](https://bioconductor.org/packages/iClusterPlus) - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3600490/)
 - 2014 - [SNF](http://compbio.cs.toronto.edu/SNF/SNF/Software.html) - [paper](https://www.ncbi.nlm.nih.gov/pubmed/24464287)
 - ...


### PR DESCRIPTION
This PR adds the STATegRa package, updated the mixOmics package link (now in bioconductor) and uses the recommended way to link to CRAN packages. 