### PR TITLE
Add RGSCA, STATIS and one review

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2008 - **PCCA** - Waaijenborg - penalized CCA / "CCA-EN" - [paper](https://doi.org/10.2202/1544-6115.1329)
 - 2009 - [Sparse mCCA](https://CRAN.r-project.org/package=PMA) - Witten - [paper 1](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2697346/), [paper 2](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2861323/)
 - 2009 - **sPLS** - Lê Cao - sparse PLS - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2640358/)
+- 2009 - [RGSCA](https://CRAN.r-project.org/package=gesca) - Hwang - regularized generalized structured component analysis - [paper](https://doi.org/10.1007/s11336-009-9119-y) 
 - 2010 - **Regularized dual CCA** - Soneson - [paper](https://doi.org/10.1186/1471-2105-11-191)
 - 2012 - **Bayesian group factor analysis** - Virtanen - [paper](http://proceedings.mlr.press/v22/virtanen12.html)
+- 2012 - [STATIS/DiSTATIS]('https://github.com/HerveAbdi/DistatisR') - Abdi - translated as 'structuring three-way statistical tables' - [paper](https://doi.org/10.1002/wics.198)
+- 2012 - 
 - 2013 - [MFA](https://cran.r-project.org/package=FactoMineR) - Abdi - multiple factor analysis - [paper](https://doi.org/10.1002/wics.1246)
 - 2013 - [JIVE](https://genome.unc.edu/jive/) - Lock - joint & individual variance explained - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671601/)
 - 2014 - [MCIA](https://bioconductor.org/packages/omicade4) - Meng - multiple co-interia analysis - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4053266/)
@@ -75,3 +78,4 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2017 - [Multi-omics approaches to disease](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1215-1)
 - 2018 - [MOVIE: Multi-Omics VIsualization of Estimated contributions](https://www.biorxiv.org/content/early/2018/07/29/379115) - [code](https://github.com/mccabes292/movie)
 - 2018 - [Multi-omic and multi-view clustering algorithms: review and cancer benchmark](https://doi.org/10.1093/nar/gky889)
+- 2018 - [Current multiblock methods: Competition or complementarity? A comparative study in a unified framework](https://doi.org/10.1016/j.chemolab.2018.09.003)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2009 - [RGSCA](https://CRAN.r-project.org/package=gesca) - Hwang - regularized generalized structured component analysis - [paper](https://doi.org/10.1007/s11336-009-9119-y) 
 - 2010 - **Regularized dual CCA** - Soneson - [paper](https://doi.org/10.1186/1471-2105-11-191)
 - 2012 - **Bayesian group factor analysis** - Virtanen - [paper](http://proceedings.mlr.press/v22/virtanen12.html)
-- 2012 - [STATIS/DiSTATIS]('https://github.com/HerveAbdi/DistatisR') - Abdi - translated as 'structuring three-way statistical tables' - [paper](https://doi.org/10.1002/wics.198)
+- 2012 - [STATIS/DiSTATIS](https://github.com/HerveAbdi/DistatisR) - Abdi - translated as 'structuring three-way statistical tables' - [paper](https://doi.org/10.1002/wics.198)
 - 2013 - [MFA](https://cran.r-project.org/package=FactoMineR) - Abdi - multiple factor analysis - [paper](https://doi.org/10.1002/wics.1246)
 - 2013 - [JIVE](https://genome.unc.edu/jive/) - Lock - joint & individual variance explained - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671601/)
 - 2014 - [MCIA](https://bioconductor.org/packages/omicade4) - Meng - multiple co-interia analysis - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4053266/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2010 - **Regularized dual CCA** - Soneson - [paper](https://doi.org/10.1186/1471-2105-11-191)
 - 2012 - **Bayesian group factor analysis** - Virtanen - [paper](http://proceedings.mlr.press/v22/virtanen12.html)
 - 2012 - [STATIS/DiSTATIS]('https://github.com/HerveAbdi/DistatisR') - Abdi - translated as 'structuring three-way statistical tables' - [paper](https://doi.org/10.1002/wics.198)
-- 2012 - 
 - 2013 - [MFA](https://cran.r-project.org/package=FactoMineR) - Abdi - multiple factor analysis - [paper](https://doi.org/10.1002/wics.1246)
 - 2013 - [JIVE](https://genome.unc.edu/jive/) - Lock - joint & individual variance explained - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671601/)
 - 2014 - [MCIA](https://bioconductor.org/packages/omicade4) - Meng - multiple co-interia analysis - [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4053266/)


### PR DESCRIPTION
Two methods added are RGSCA from Hwang & Takane, and STATIS/DiSTATIS from Abdi et al.
One review comparing RGSCA, RGCCA, and THEME is added to the Multi-omics reviews category.