### PR TITLE
Add mLLMCelltype to Single cell multi-omics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2018 - [clonealign](https://github.com/kieranrcampbell/clonealign) - Campbell - gene expression states to clones (scRNA-seq + scDNA-seq (CNV)) - [paper](https://doi.org/10.1101/344309)
 - 2020 - [CiteFuse](https://sydneybiox.github.io/CiteFuse/) - Kim - CITE-seq data analysis [paper](https://doi.org/10.1093/bioinformatics/btaa282)
 - 2021 - [CoSpar](https://cospar.readthedocs.io/) - Wang - infer dynamics by integrating state and lineage information - [paper](https://www.biorxiv.org/content/10.1101/2021.05.06.443026v1)
+- 2025 - [mLLMCelltype](https://github.com/cafferychen777/mLLMCelltype) - Yang - Multi-model framework for single-cell RNA-seq cell type annotation with uncertainty quantification - [paper](https://doi.org/10.1101/2025.04.10.647852)
 
 ### Multi-study correlation or factor analysis
 


### PR DESCRIPTION
Hi,

I'm adding mLLMCelltype, a multi-model framework for single-cell RNA-seq cell type annotation, to the Single cell multi-omics section.

mLLMCelltype uses multiple large language models (GPT-4o, Claude 3.7, Gemini 2.5 Pro, Deepseek, Qwen) to reach a consensus on cell type annotations with uncertainty quantification. It provides transparent reasoning for annotations and high-quality visualization of results.

The tool is available in both R and Python implementations, with the Python version supporting AnnData objects, making it compatible with many single-cell analysis workflows.

GitHub repository: [https://github.com/cafferychen777/mLLMCelltype](https://github.com/cafferychen777/mLLMCelltype)
Preprint: [https://doi.org/10.1101/2025.04.10.647852](https://doi.org/10.1101/2025.04.10.647852)