### PR TITLE
Add omicau to Multi-omics data management

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ For brevity, below lists only the first author of multi-omics methods.
 - 2017 - [MultiAssayExperiment](https://bioconductor.org/packages/MultiAssayExperiment/) - Ramos - Software for the integration of multi-omics experiments in Bioconductor - [paper](https://doi.org/10.1158/0008-5472.CAN-17-0344).
 - 2021 - [muon](https://github.com/pmbio/muon) - Bredikhin - [Multimodal omics analysis framework](https://doi.org/10.1101/2021.06.01.445670)
 - 2025 - [Omilayers](https://github.com/dkioroglou/omilayers) - Kioroglou - Python package for efficient data management to support multi-omic analysis - [paper](https://doi.org/10.1186/s12859-025-06067-7), [docs](https://omilayers.readthedocs.io/en/latest/)
+- 2026 - [omicau](https://github.com/tunabirgun/omicau) - Birgün - leakage-safe data audit and benchmarking
 
 ## Multi-omics visualization
 


### PR DESCRIPTION
Adds **omicau** to *Software packages and methods → Multi-omics data management*, in the list's format (`YEAR - [name](link) - author - short description`), placed chronologically (2026, software release).

omicau is a reproducible, leakage-safe multi-omics **data-audit and fusion-benchmarking** CLI: format-agnostic ingestion and alignment, SHA-256 data provenance, missingness-bias and batch-effect diagnostics, group-aware cross-validated classical and PyTorch fusion benchmarks with leakage-safe feature attribution, and a clinical/research dashboard.

Repo: https://github.com/tunabirgun/omicau · Apache-2.0. Software release (no preprint yet), so YEAR is the release date per the contributing guide. Happy to recategorize if you'd prefer the clustering/classification/prediction section. Disclosure: I'm the author.